### PR TITLE
Add Whisper fallback for missing transcripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,13 @@ Then reload your shell configuration:
 source ~/.bashrc  # or source ~/.zshrc for zsh users
 ```
 
+To enable automatic fallback transcription with [Whisper](https://github.com/openai/whisper),
+install the optional dependencies:
+
+```bash
+pip install yt-dlp openai-whisper
+```
+
 ### 2. Alfred Workflow Integration (macOS)
 
 For quick access to transcripts directly from Alfred:
@@ -123,6 +130,7 @@ The tool supports various YouTube URL formats:
 - Handles various YouTube URL formats
 - Uses TextFormatter for clean transcript output
 - Alfred workflow integration for quick access (macOS)
+- Falls back to Whisper-based transcription when captions are unavailable
 
 ## Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ python = "^3.8"
 youtube-transcript-api = "^0.6.1"
 pyperclip = "^1.8.2"
 requests = "^2.31.0"
+yt-dlp = "^2024.4.9"
+openai-whisper = "^2024.9.30"
 
 [tool.poetry.scripts]
 y2t = "y2t:main"

--- a/tests/test_y2t.py
+++ b/tests/test_y2t.py
@@ -1,4 +1,5 @@
 import pytest
+import y2t
 from y2t import extract_video_id, get_transcript, clean_filename, get_video_info
 from youtube_transcript_api import YouTubeTranscriptApi, TranscriptsDisabled
 from youtube_transcript_api.formatters import TextFormatter
@@ -153,10 +154,10 @@ def test_get_transcript_no_captions(mocker):
         "list_transcripts",
         side_effect=TranscriptsDisabled("Transcripts are disabled for this video"),
     )
+    mocker.patch("y2t.transcribe_with_whisper", return_value="fallback text")
 
-    with pytest.raises(SystemExit) as exc_info:
-        get_transcript("jNQXAC9IVRw")
-    assert exc_info.value.code == 1
+    get_transcript("jNQXAC9IVRw")
+    y2t.transcribe_with_whisper.assert_called_once_with("jNQXAC9IVRw")
 
 
 if __name__ == "__main__":

--- a/y2t/__init__.py
+++ b/y2t/__init__.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 
 import argparse
-import re
 import os
+import re
+import tempfile
 from typing import Optional, Tuple
-from youtube_transcript_api import YouTubeTranscriptApi
-from youtube_transcript_api.formatters import TextFormatter
+
 import pyperclip
 import requests
+from youtube_transcript_api import YouTubeTranscriptApi
+from youtube_transcript_api.formatters import TextFormatter
 
 
 def clean_filename(title: str) -> str:
@@ -51,6 +53,34 @@ def extract_video_id(url: str) -> str:
     raise ValueError("Invalid YouTube URL")
 
 
+def transcribe_with_whisper(video_id: str) -> str:
+    """Download audio and transcribe it using Whisper."""
+    from yt_dlp import YoutubeDL
+    import whisper
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpl = os.path.join(tmpdir, "%(id)s.%(ext)s")
+        ydl_opts = {
+            "outtmpl": tmpl,
+            "format": "bestaudio/best",
+            "quiet": True,
+            "postprocessors": [
+                {
+                    "key": "FFmpegExtractAudio",
+                    "preferredcodec": "mp3",
+                    "preferredquality": "192",
+                }
+            ],
+        }
+        with YoutubeDL(ydl_opts) as ydl:
+            ydl.download([f"https://www.youtube.com/watch?v={video_id}"])
+
+        mp3_path = os.path.join(tmpdir, f"{video_id}.mp3")
+        model = whisper.load_model("base")
+        result = model.transcribe(mp3_path)
+        return result["text"].strip()
+
+
 def get_transcript(
     video_id: str,
     output_file: Optional[str] = None,
@@ -72,7 +102,13 @@ def get_transcript(
         formatter = TextFormatter()
 
         formatted_transcript = formatter.format_transcript(transcript.fetch())
+    except Exception as e:
+        print(
+            f"Failed to fetch transcript via API: {e}\nFalling back to Whisper..."
+        )
+        formatted_transcript = transcribe_with_whisper(video_id)
 
+    try:
         if output_dir:
             # Get video title and create filename
             _, filename = get_video_info(video_id)


### PR DESCRIPTION
## Summary
- fallback to Whisper transcription when YouTube captions can't be fetched
- add optional dependencies and update README
- update tests for Whisper fallback

## Testing
- `poetry run pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684dd2fd31ac832b9f5a0522b3810c72